### PR TITLE
Signature helper

### DIFF
--- a/src/cljParser.ts
+++ b/src/cljParser.ts
@@ -1,0 +1,133 @@
+'use strict';
+
+interface ExpressionInfo {
+    functionName: string;
+    parameterPosition: number;
+}
+
+interface RelativeExpressionInfo {
+    startPosition: number;
+    parameterPosition: number;
+}
+
+const CLJ_TEXT_DELIMITER = `"`;
+const CLJ_TEXT_ESCAPE = `\\`;
+const CLJ_COMMENT_DELIMITER = `;`;
+export const R_CLJ_WHITE_SPACE = /\s|,/;
+const R_CLJ_OPERATOR_DELIMITERS = /\s|,|\(|{|\[/;
+
+/** { close_char open_char } */
+const CLJ_EXPRESSION_DELIMITERS: Map<string, string> = new Map<string, string>([
+    [`}`, `{`],
+    [`)`, `(`],
+    [`]`, `[`],
+    [CLJ_TEXT_DELIMITER, CLJ_TEXT_DELIMITER],
+]);
+
+export function getExpressionInfo(text: string): ExpressionInfo {
+    text = removeCljComments(text);
+    const relativeExpressionInfo = getRelativeExpressionInfo(text);
+    if (!relativeExpressionInfo)
+        return;
+
+    let functionName = text.substring(relativeExpressionInfo.startPosition + 1); // expression openning ignored
+    functionName = functionName.substring(functionName.search(/[^,\s]/)); // trim left
+    functionName = functionName.substring(0, functionName.search(R_CLJ_OPERATOR_DELIMITERS)); // trim right according to operator delimiter
+
+    if (!functionName.length)
+        return;
+
+    return {
+        functionName,
+        parameterPosition: relativeExpressionInfo.parameterPosition,
+    };
+}
+
+function removeCljComments(text: string): string {
+    const lines = text.match(/[^\r\n]+/g); // split string by line
+
+    if (lines.length > 1) {
+        return lines.map(line => removeCljComments(line)).join(`\n`); // remove comments from each line and concat them again after
+    }
+
+    const line = lines[0];
+    let uncommentedIndex = line.length;
+    let insideString = false;
+    for (let i = 0; i < line.length; i++) {
+        if (line[i] === CLJ_TEXT_DELIMITER) {
+            insideString = !insideString || line[i - 1] === CLJ_TEXT_ESCAPE;
+            continue;
+        }
+        if (line[i] === CLJ_COMMENT_DELIMITER && !insideString) { // ignore comment delimiter inside a string
+            uncommentedIndex = i;
+            break;
+        }
+    }
+
+    return line.substring(0, uncommentedIndex);
+}
+
+function getRelativeExpressionInfo(text: string, openChar: string = `(`): RelativeExpressionInfo {
+    const relativeExpressionInfo: RelativeExpressionInfo = {
+        startPosition: text.length - 1,
+        parameterPosition: -1,
+    };
+
+    let newParameterFound = false;
+    while (relativeExpressionInfo.startPosition >= 0) {
+        const char = text[relativeExpressionInfo.startPosition];
+
+        // check if found the beginning of the expression (string escape taken care of)
+        if (char === openChar && (openChar !== CLJ_TEXT_DELIMITER || (text[relativeExpressionInfo.startPosition - 1] !== CLJ_TEXT_ESCAPE))) {
+            if (newParameterFound) // ignore one parameter found if it's actually the function we're looking for
+                relativeExpressionInfo.parameterPosition--;
+            return relativeExpressionInfo;
+        }
+
+        // ignore everything if searching inside a string
+        if (openChar === CLJ_TEXT_DELIMITER) {
+            relativeExpressionInfo.startPosition--;
+            continue;
+        }
+
+        // invalid code if a beginning of an expression is found without being searched for
+        if (char !== CLJ_TEXT_DELIMITER && containsValue(CLJ_EXPRESSION_DELIMITERS, char))
+            return;
+
+        // keep searching if it's white space
+        if (R_CLJ_WHITE_SPACE.test(char)) {
+            if (!newParameterFound) {
+                relativeExpressionInfo.parameterPosition++;
+                newParameterFound = true;
+            }
+            relativeExpressionInfo.startPosition--;
+            continue;
+        }
+
+        // check for new expressions
+        const expressionDelimiter = CLJ_EXPRESSION_DELIMITERS.get(char);
+        if (!!expressionDelimiter) {
+            const innerExpressionInfo = getRelativeExpressionInfo(text.substring(0, relativeExpressionInfo.startPosition), expressionDelimiter);
+            if (!innerExpressionInfo)
+                return;
+
+            relativeExpressionInfo.startPosition = innerExpressionInfo.startPosition - 1;
+            relativeExpressionInfo.parameterPosition++;
+            newParameterFound = true;
+            continue;
+        }
+
+        newParameterFound = false;
+        relativeExpressionInfo.startPosition--;
+    }
+
+    return; // reached the beginning of the text without finding the start of the expression
+}
+
+function containsValue(map: Map<any, any>, checkValue: any): boolean {
+    for (let value of map.values()) {
+        if (value === checkValue)
+            return true;
+    }
+    return false;
+}

--- a/src/clojureMain.ts
+++ b/src/clojureMain.ts
@@ -1,34 +1,18 @@
 'use strict';
 
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import {
-    CLOJURE_MODE
-} from './clojureMode';
-import {
-    ClojureCompletionItemProvider
-} from './clojureSuggest';
-import {
-    clojureEval
-} from './clojureEval';
-import {
-    ClojureDefinitionProvider
-} from './clojureDefinition';
-import {
-    ClojureLanguageConfiguration
-} from './clojureConfiguration'
-import {
-    ClojureHoverProvider
-} from './clojureHover'
-import {
-    nREPLClient
-} from './nreplClient';
-import {
-    JarContentProvider
-} from './jarContentProvider';
+import { CLOJURE_MODE } from './clojureMode';
+import { ClojureCompletionItemProvider } from './clojureSuggest';
+import { clojureEval } from './clojureEval';
+import { ClojureDefinitionProvider } from './clojureDefinition';
+import { ClojureLanguageConfiguration } from './clojureConfiguration';
+import { ClojureHoverProvider } from './clojureHover';
+import { ClojureSignatureProvider } from './clojureSignature';
+import { nREPLClient } from './nreplClient';
+import { JarContentProvider } from './jarContentProvider';
 
 let connectionIndicator = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
 
@@ -107,12 +91,13 @@ function connect(context: vscode.ExtensionContext) {
 
 export function activate(context: vscode.ExtensionContext) {
     let evaluationResultChannel = vscode.window.createOutputChannel('Evaluation results');
-    vscode.commands.registerCommand('clojureVSCode.connect', () => {connect(context)});
-    vscode.commands.registerCommand('clojureVSCode.eval', () => {clojureEval(context)});
-    vscode.commands.registerCommand('clojureVSCode.evalAndShowResult', () => {clojureEval(context, evaluationResultChannel)});
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(CLOJURE_MODE, new ClojureCompletionItemProvider(context), '.', '/'))
+    vscode.commands.registerCommand('clojureVSCode.connect', () => { connect(context) });
+    vscode.commands.registerCommand('clojureVSCode.eval', () => { clojureEval(context) });
+    vscode.commands.registerCommand('clojureVSCode.evalAndShowResult', () => { clojureEval(context, evaluationResultChannel) });
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(CLOJURE_MODE, new ClojureCompletionItemProvider(context), '.', '/'));
     context.subscriptions.push(vscode.languages.registerDefinitionProvider(CLOJURE_MODE, new ClojureDefinitionProvider(context)));
     context.subscriptions.push(vscode.languages.registerHoverProvider(CLOJURE_MODE, new ClojureHoverProvider(context)));
+    context.subscriptions.push(vscode.languages.registerSignatureHelpProvider(CLOJURE_MODE, new ClojureSignatureProvider(context), ' ', '\n'));
     vscode.workspace.registerTextDocumentContentProvider('jar', new JarContentProvider());
     vscode.languages.setLanguageConfiguration(CLOJURE_MODE.language, new ClojureLanguageConfiguration());
 
@@ -120,7 +105,7 @@ export function activate(context: vscode.ExtensionContext) {
     updateConnectionParams(context);
     let port = context.workspaceState.get<number>('port');
     let host = context.workspaceState.get<string>('host');
-    if (port && host ) {
+    if (port && host) {
         updateConnectionIndicator(port, host);
         testConnection(port, host, (response) => {
             vscode.window.showInformationMessage(onSuccesfullConnectMessage)
@@ -128,4 +113,4 @@ export function activate(context: vscode.ExtensionContext) {
     }
 }
 
-export function deactivate() {}
+export function deactivate() { }

--- a/src/clojureSignature.ts
+++ b/src/clojureSignature.ts
@@ -1,39 +1,118 @@
 'use strict';
 
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
 import * as vscode from 'vscode';
-import {
-    nREPLClient
-} from './nreplClient';
-import {
-    ClojureProvider
-} from './clojureProvider';
+
+import { ClojureProvider } from './clojureProvider';
+import * as cljParser from './cljParser';
+
+const PARAMETER_OPEN = `[`;
+const PARAMETER_CLOSE = `]`;
+const PARAMETER_REST = `&`;
 
 export class ClojureSignatureProvider extends ClojureProvider implements vscode.SignatureHelpProvider {
 
-    provideSignatureHelp(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable < vscode.SignatureHelp > {
-        return new Promise < vscode.SignatureHelp > ((resolve, reject) => {
-            let wordRange = document.getWordRangeAtPosition(position);
-            if (wordRange === undefined) {
-                return reject(); //resolve(new vscode.Hover('Docstring not found'));
-            }
-            let currentWord: string;
-            currentWord = document.lineAt(position.line).text.slice(wordRange.start.character, wordRange.end.character);
-            let ns = this.getNamespace(document.getText());
+    provideSignatureHelp(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.SignatureHelp> {
+        const textToGetInfo = document.getText(new vscode.Range(new vscode.Position(0, 0), position));
+        const exprInfo = cljParser.getExpressionInfo(textToGetInfo);
+        if (!exprInfo)
+            return;
 
-            let nrepl = this.getNREPL();
-            nrepl.info(currentWord, ns, (info) => {
-                if (info.doc) {
-                    let signatureHelp = new vscode.SignatureHelp();
-                    signatureHelp.activeParameter = 0;
-                    signatureHelp.activeSignature = 0;
-                    signatureHelp.signatures = [new vscode.SignatureInformation('a b c')]
-                    resolve(signatureHelp);
-                }
-                reject();
+        const ns = this.getNamespace(document.getText());
+
+        return new Promise<vscode.SignatureHelp>((resolve, reject) => {
+            this.getNREPL().info(exprInfo.functionName, ns, info => {
+                resolve(getSignatureHelp(info, exprInfo.parameterPosition));
             });
         });
     }
+
+}
+
+function getSignatureHelp(info, parameterPosition): vscode.SignatureHelp {
+    const signatures = getSignatureInfos(info);
+    signatures.sort((sig1, sig2) => sig1.parameters.length - sig2.parameters.length);
+
+    let activeSignature = signatures.findIndex(signature => signature.parameters.length >= parameterPosition + 1);
+    if (activeSignature === -1) {
+        activeSignature = signatures.findIndex(signature => signature.parameters.some(param => param.label.startsWith(PARAMETER_REST)));
+        if (activeSignature != -1)
+            parameterPosition = signatures[activeSignature].parameters.length - 1;
+    }
+
+    const signatureHelp = new vscode.SignatureHelp();
+    signatureHelp.signatures = signatures;
+    signatureHelp.activeParameter = parameterPosition;
+    signatureHelp.activeSignature = activeSignature;
+
+    return signatureHelp;
+}
+
+function getSignatureInfos(info: any): vscode.SignatureInformation[] {
+    const arglists: string = info['arglists-str'];
+
+    const sigParamStarts: number[] = [];
+    const sigParamStops: number[] = [];
+    let nestingLevel = 0;
+    for (let i = 0; i < arglists.length; i++) {
+        if (arglists[i] === PARAMETER_OPEN) {
+            if (nestingLevel === 0)
+                sigParamStarts.push(i);
+            nestingLevel++;
+        }
+        if (arglists[i] === PARAMETER_CLOSE) {
+            nestingLevel--;
+            if (nestingLevel === 0)
+                sigParamStops.push(i);
+        }
+    }
+
+    return sigParamStarts
+        .map((sigParamStart, index) => arglists.substring(sigParamStart, sigParamStops[index] + 1))
+        .map(signatureParameter => {
+            const parameterInfos = getParameterInfos(signatureParameter);
+            const sigInfo = new vscode.SignatureInformation(`${info.ns}/${info.name} [${parameterInfos.map(pi => pi.label).join(`\n`)}]`);
+            sigInfo.documentation = info.doc;
+            sigInfo.parameters = parameterInfos;
+            return sigInfo;
+        });
+}
+
+function getParameterInfos(signatureParameter: string): vscode.ParameterInformation[] {
+    signatureParameter = signatureParameter.substring(1, signatureParameter.length - 1); // removing external brackets
+    const paramStarts: number[] = [];
+    const paramStops: number[] = [];
+    let insideParameter = false;
+    let bracketsNestingLevel = 0;
+    for (let i = 0; i < signatureParameter.length; i++) {
+        const char = signatureParameter[i];
+
+        if (!insideParameter) {
+            insideParameter = true;
+            paramStarts.push(i);
+            if (char === PARAMETER_OPEN)
+                bracketsNestingLevel++;
+            if (char === PARAMETER_REST)
+                break;
+        } else {
+            if (char === PARAMETER_OPEN)
+                bracketsNestingLevel++;
+            if (char === PARAMETER_CLOSE)
+                bracketsNestingLevel--;
+            if (char === PARAMETER_CLOSE && bracketsNestingLevel === 0) {
+                paramStops.push(i);
+                insideParameter = false;
+            }
+            if (cljParser.R_CLJ_WHITE_SPACE.test(char) && bracketsNestingLevel === 0) {
+                paramStops.push(i);
+                insideParameter = false;
+            }
+        }
+    }
+    paramStops.push(signatureParameter.length);
+
+    return paramStarts
+        .map((paramStart, index) => signatureParameter.substring(paramStart, paramStops[index] + 1))
+        .map(parameter => {
+            return new vscode.ParameterInformation(parameter);
+        });
 }

--- a/src/clojureSignature.ts
+++ b/src/clojureSignature.ts
@@ -8,6 +8,8 @@ import * as cljParser from './cljParser';
 const PARAMETER_OPEN = `[`;
 const PARAMETER_CLOSE = `]`;
 const PARAMETER_REST = `&`;
+const UNSUPPORTED_SIGNATURE_NAMES = ['.', 'new', 'fn', 'set!']; // they have forms that do not follow the same rules as other special forms
+const SPECIAL_FORM_PARAMETER_REST = `*`;
 
 export class ClojureSignatureProvider extends ClojureProvider implements vscode.SignatureHelpProvider {
 
@@ -21,23 +23,58 @@ export class ClojureSignatureProvider extends ClojureProvider implements vscode.
 
         return new Promise<vscode.SignatureHelp>((resolve, reject) => {
             this.getNREPL().info(exprInfo.functionName, ns, info => {
-                resolve(getSignatureHelp(info, exprInfo.parameterPosition));
+                if (!info.name) // sometimes info brings just a list of suggestions (example: .MAX_VALUE)
+                    return resolve();
+
+                if (!!info['special-form'])
+                    return resolve(getSpecialFormSignatureHelp(info, exprInfo.parameterPosition));
+
+                return resolve(getFunctionSignatureHelp(info, exprInfo.parameterPosition));
             });
         });
     }
 
 }
 
-function getSignatureHelp(info, parameterPosition): vscode.SignatureHelp {
-    const signatures = getSignatureInfos(info);
+function getSpecialFormSignatureHelp(info: any, parameterPosition: number): vscode.SignatureHelp {
+    if (UNSUPPORTED_SIGNATURE_NAMES.indexOf(info.name) > -1) {
+        const signatureHelp = new vscode.SignatureHelp();
+        signatureHelp.signatures = [new vscode.SignatureInformation(`${info.name} *special form* ${info['forms-str']}`, info.doc)];
+        signatureHelp.activeSignature = 0;
+
+        return signatureHelp;
+    }
+
+    const forms: string = info['forms-str'];
+    const [functionName, ...parameters] = forms.substring(3, forms.length - 1).split(' ');
+    const parameterInfos = parameters.map(parameter => new vscode.ParameterInformation(parameter));
+
+    const sigInfo = new vscode.SignatureInformation(`${info.name} *special form* [${parameterInfos.map(pi => pi.label).join(`\n`)}]`, info.doc);
+    sigInfo.parameters = parameterInfos;
+
+    if (parameterPosition + 1 > sigInfo.parameters.length && sigInfo.parameters[sigInfo.parameters.length - 1].label.endsWith(SPECIAL_FORM_PARAMETER_REST))
+        parameterPosition = sigInfo.parameters.length - 1;
+
+    const signatureHelp = new vscode.SignatureHelp();
+    signatureHelp.signatures = [sigInfo];
+    signatureHelp.activeParameter = parameterPosition;
+    signatureHelp.activeSignature = 0;
+
+    return signatureHelp;
+}
+
+function getFunctionSignatureHelp(info: any, parameterPosition: number): vscode.SignatureHelp {
+    const signatures = getFunctionSignatureInfos(info);
     signatures.sort((sig1, sig2) => sig1.parameters.length - sig2.parameters.length);
 
     let activeSignature = signatures.findIndex(signature => signature.parameters.length >= parameterPosition + 1);
     if (activeSignature === -1) {
         activeSignature = signatures.findIndex(signature => signature.parameters.some(param => param.label.startsWith(PARAMETER_REST)));
-        if (activeSignature != -1)
+        if (activeSignature !== -1)
             parameterPosition = signatures[activeSignature].parameters.length - 1;
     }
+    if (activeSignature === -1)
+        activeSignature = 0;
 
     const signatureHelp = new vscode.SignatureHelp();
     signatureHelp.signatures = signatures;
@@ -47,7 +84,7 @@ function getSignatureHelp(info, parameterPosition): vscode.SignatureHelp {
     return signatureHelp;
 }
 
-function getSignatureInfos(info: any): vscode.SignatureInformation[] {
+function getFunctionSignatureInfos(info: any): vscode.SignatureInformation[] {
     const arglists: string = info['arglists-str'];
 
     const sigParamStarts: number[] = [];
@@ -69,7 +106,7 @@ function getSignatureInfos(info: any): vscode.SignatureInformation[] {
     return sigParamStarts
         .map((sigParamStart, index) => arglists.substring(sigParamStart, sigParamStops[index] + 1))
         .map(signatureParameter => {
-            const parameterInfos = getParameterInfos(signatureParameter);
+            const parameterInfos = getFunctionParameterInfos(signatureParameter);
             const sigInfo = new vscode.SignatureInformation(`${info.ns}/${info.name} [${parameterInfos.map(pi => pi.label).join(`\n`)}]`);
             sigInfo.documentation = info.doc;
             sigInfo.parameters = parameterInfos;
@@ -77,7 +114,7 @@ function getSignatureInfos(info: any): vscode.SignatureInformation[] {
         });
 }
 
-function getParameterInfos(signatureParameter: string): vscode.ParameterInformation[] {
+function getFunctionParameterInfos(signatureParameter: string): vscode.ParameterInformation[] {
     signatureParameter = signatureParameter.substring(1, signatureParameter.length - 1); // removing external brackets
     const paramStarts: number[] = [];
     const paramStops: number[] = [];
@@ -112,7 +149,5 @@ function getParameterInfos(signatureParameter: string): vscode.ParameterInformat
 
     return paramStarts
         .map((paramStart, index) => signatureParameter.substring(paramStart, paramStops[index] + 1))
-        .map(parameter => {
-            return new vscode.ParameterInformation(parameter);
-        });
+        .map(parameter => new vscode.ParameterInformation(parameter));
 }


### PR DESCRIPTION
Tries to provide the function signature helper when the user is filling parameters.

Given the cursor position, we try to find the first parameter of the list (in clojure, that's the operand) and the position of the parameter the user is filling in. We do that with reverse parsing since, at the cursor position, we don't have a complete clojure expression yet.

With the operand name, we get the documentation with its possible parameters to build the signature helper. With the parameter position, we try to find the most appropriate signature for the user (the signature with the least number of parameters still suitable for the given parameter position).

Closes #8