### PR TITLE
Errors shown in OUTPUT Panel with stacktrace

### DIFF
--- a/src/clojureMain.ts
+++ b/src/clojureMain.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 
 import { CLOJURE_MODE } from './clojureMode';
 import { ClojureCompletionItemProvider } from './clojureSuggest';
-import { clojureEval } from './clojureEval';
+import { clojureEval, clojureEvalAndShowResult } from './clojureEval';
 import { ClojureDefinitionProvider } from './clojureDefinition';
 import { ClojureLanguageConfiguration } from './clojureConfiguration';
 import { ClojureHoverProvider } from './clojureHover';
@@ -14,7 +14,7 @@ import { ClojureSignatureProvider } from './clojureSignature';
 import { nREPLClient } from './nreplClient';
 import { JarContentProvider } from './jarContentProvider';
 
-let connectionIndicator = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+const connectionIndicator = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
 
 function updateConnectionIndicator(port: number, host: string) {
     connectionIndicator.text = `⚡nrepl://${host}:${port}`;
@@ -32,9 +32,9 @@ function updateConnectionParams(context: vscode.ExtensionContext): void {
     let projectDir = vscode.workspace.rootPath;
 
     if (projectDir) {
-        let localNREPLFile = path.join(projectDir, '.nrepl-port');
+        const localNREPLFile = path.join(projectDir, '.nrepl-port');
         if (fs.existsSync(localNREPLFile)) {
-            nreplPort = Number.parseInt(fs.readFileSync(localNREPLFile, 'utf-8'))
+            nreplPort = Number.parseInt(fs.readFileSync(localNREPLFile, 'utf-8'));
         }
     }
 
@@ -64,7 +64,7 @@ function connect(context: vscode.ExtensionContext) {
         }
         port = Number.parseInt(value);
         if (!port) {
-            vscode.window.showErrorMessage('Port number should be an integer.')
+            vscode.window.showErrorMessage('Port number should be an integer.');
             return Promise.reject(false);
         }
     }).then((value) => {
@@ -90,10 +90,10 @@ function connect(context: vscode.ExtensionContext) {
 }
 
 export function activate(context: vscode.ExtensionContext) {
-    let evaluationResultChannel = vscode.window.createOutputChannel('Evaluation results');
+    const evaluationResultChannel = vscode.window.createOutputChannel('Evaluation results');
     vscode.commands.registerCommand('clojureVSCode.connect', () => { connect(context) });
-    vscode.commands.registerCommand('clojureVSCode.eval', () => { clojureEval(context) });
-    vscode.commands.registerCommand('clojureVSCode.evalAndShowResult', () => { clojureEval(context, evaluationResultChannel) });
+    vscode.commands.registerCommand('clojureVSCode.eval', () => { clojureEval(context, evaluationResultChannel) });
+    vscode.commands.registerCommand('clojureVSCode.evalAndShowResult', () => { clojureEvalAndShowResult(context, evaluationResultChannel) });
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider(CLOJURE_MODE, new ClojureCompletionItemProvider(context), '.', '/'));
     context.subscriptions.push(vscode.languages.registerDefinitionProvider(CLOJURE_MODE, new ClojureDefinitionProvider(context)));
     context.subscriptions.push(vscode.languages.registerHoverProvider(CLOJURE_MODE, new ClojureHoverProvider(context)));
@@ -108,7 +108,7 @@ export function activate(context: vscode.ExtensionContext) {
     if (port && host) {
         updateConnectionIndicator(port, host);
         testConnection(port, host, (response) => {
-            vscode.window.showInformationMessage(onSuccesfullConnectMessage)
+            vscode.window.showInformationMessage(onSuccesfullConnectMessage);
         });
     }
 }

--- a/src/clojureProvider.ts
+++ b/src/clojureProvider.ts
@@ -1,12 +1,8 @@
 'use strinct';
 
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
 import * as vscode from 'vscode';
-import {
-    nREPLClient
-} from './nreplClient';
+
+import { nREPLClient } from './nreplClient';
 
 /**
  * Base class for Clojure providers.
@@ -18,7 +14,7 @@ export class ClojureProvider {
     /**
      * @param context Extention context
      */
-    constructor(context : vscode.ExtensionContext) {
+    constructor(context: vscode.ExtensionContext) {
         this.context = context;
     }
 
@@ -28,8 +24,8 @@ export class ClojureProvider {
     protected getNREPL(): nREPLClient {
         let port: number;
         let host: string;
-        port = this.context.workspaceState.get< number >('port');
-        host = this.context.workspaceState.get< string >('host');
+        port = this.context.workspaceState.get<number>('port');
+        host = this.context.workspaceState.get<string>('host');
         return new nREPLClient(port, host);
     }
 
@@ -39,7 +35,12 @@ export class ClojureProvider {
      * @param text Clojure code snippet
      */
     protected getNamespace(text): string {
-        let m = text.match(/^[\s\t]*\((?:[\s\t\n]*(?:in-){0,1}ns)[\s\t\n]+'?([\w\-.]+)[\s\S]*\)[\s\S]*/);
-        return m ? m[1] : 'user';
+        return getNamespace(text);
     }
+
+}
+
+export function getNamespace(text: string): string {
+    const m = text.match(/^[\s\t]*\((?:[\s\t\n]*(?:in-){0,1}ns)[\s\t\n]+'?([\w\-.]+)[\s\S]*\)[\s\S]*/);
+    return m ? m[1] : 'user';
 }

--- a/src/nreplClient.ts
+++ b/src/nreplClient.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import * as net from 'net';
-import {Buffer} from 'buffer';
+import { Buffer } from 'buffer';
 
 import * as bencodeUtil from './bencodeUtil';
 
@@ -54,44 +54,44 @@ export class nREPLClient {
     }
 
     public complete(symbol: string, ns: string, callback) {
-        let msg: nREPLCompleteMessage = {op: 'complete', symbol: symbol, ns: ns};
+        const msg: nREPLCompleteMessage = { op: 'complete', symbol: symbol, ns: ns };
         this.send(msg).then(respObjs => callback(respObjs[0]));
     }
 
     public info(symbol: string, ns: string, callback) {
-        let msg: nREPLInfoMessage = {op: 'info', symbol: symbol, ns: ns};
+        const msg: nREPLInfoMessage = { op: 'info', symbol: symbol, ns: ns };
         this.send(msg).then(respObjs => callback(respObjs[0]));
     }
 
     public eval(code: string): Promise<any[]> {
         return this.clone().then((new_session) => {
-            let session_id = new_session['new-session'];
-            let msg: nREPLSingleEvalMessage = {op: 'eval', code: code, session: session_id};
+            const session_id = new_session['new-session'];
+            const msg: nREPLSingleEvalMessage = { op: 'eval', code: code, session: session_id };
             return this.send(msg);
         });
     }
 
     public evalFile(code: string, filepath: string): Promise<any[]> {
         return this.clone().then((new_session) => {
-            let session_id = new_session['new-session'];
-            let msg: nREPLEvalMessage = {op: 'load-file', file: code, 'file-path': filepath, session: session_id};
+            const session_id = new_session['new-session'];
+            const msg: nREPLEvalMessage = { op: 'load-file', file: code, 'file-path': filepath, session: session_id };
             return this.send(msg);
         });
     }
 
-    public stacktrace(session: string, callback) {
-        let msg: nREPLStacktraceMessage = {op: 'stacktrace', session: session};
-        this.send(msg).then(respObjs => callback(respObjs[0]));
+    public stacktrace(session: string): Promise<any> {
+        const msg: nREPLStacktraceMessage = { op: 'stacktrace', session: session };
+        return this.send(msg);
     }
 
     public clone(): Promise<any[]> {
-        let msg = {op: 'clone'};
+        const msg = { op: 'clone' };
         return this.send(msg).then(respObjs => respObjs[0]);
     }
 
-    public close(callback) {
-        let msg: nREPLCloseMessage = {op: 'close'};
-        this.send(msg).then(respObjs => callback(respObjs));
+    public close(): Promise<any[]> {
+        const msg: nREPLCloseMessage = { op: 'close' };
+        return this.send(msg);
     }
 
     private send(msg: nREPLCompleteMessage | nREPLInfoMessage | nREPLEvalMessage | nREPLStacktraceMessage | nREPLCloneMessage | nREPLCloseMessage | nREPLSingleEvalMessage): Promise<any[]> {
@@ -109,7 +109,7 @@ export class nREPLClient {
             const respObjects = [];
             client.on('data', data => {
                 nreplResp = Buffer.concat([nreplResp, data]);
-                const {decodedObjects, rest} = bencodeUtil.decodeObjects(nreplResp);
+                const { decodedObjects, rest } = bencodeUtil.decodeObjects(nreplResp);
                 nreplResp = rest;
                 const validDecodedObjects = decodedObjects.reduce((objs, obj) => {
                     if (!isLastNreplObject(objs))


### PR DESCRIPTION
Instead of using the PROBLEMS Panel, we use now the OUTPUT Panel to show errors raised during eval. It shows the error message with the stacktrace as well.

This closes #28 and closes #4.