### PR TITLE
Promise-ify nreplClient.ts.

### DIFF
--- a/src/clojureDefinition.ts
+++ b/src/clojureDefinition.ts
@@ -14,20 +14,18 @@ export class ClojureDefinitionProvider implements vscode.DefinitionProvider {
         if (!wordRange)
             return Promise.reject('No word selected.');
 
-        return new Promise((resolve, reject) => {
-            const currentWord: string = document.lineAt(position.line).text.slice(wordRange.start.character, wordRange.end.character);
-            const ns = cljParser.getNamespace(document.getText());
+        const currentWord: string = document.lineAt(position.line).text.slice(wordRange.start.character, wordRange.end.character);
+        const ns = cljParser.getNamespace(document.getText());
 
-            nreplClient.info(currentWord, ns, (info) => {
-                if (!info.file)
-                    return reject('No word definition found.');
+        return nreplClient.info(currentWord, ns).then(info => {
+            if (!info.file)
+                return Promise.reject('No word definition found.');
 
-                let uri = vscode.Uri.parse(info.file);
-                let pos = new vscode.Position(info.line - 1, info.column)
-                let definition = new vscode.Location(uri, pos);
-                resolve(definition);
-            });
-        })
+            let uri = vscode.Uri.parse(info.file);
+            let pos = new vscode.Position(info.line - 1, info.column)
+            let definition = new vscode.Location(uri, pos);
+            return Promise.resolve(definition);
+        });
     }
 
 }

--- a/src/clojureHover.ts
+++ b/src/clojureHover.ts
@@ -10,22 +10,19 @@ export class ClojureHoverProvider implements vscode.HoverProvider {
         if (!cljConnection.isConnected())
             return Promise.reject('No nREPL connected.');
 
-        return new Promise<vscode.Hover>((resolve, reject) => {
-            let wordRange = document.getWordRangeAtPosition(position);
-            if (wordRange === undefined) {
-                resolve(new vscode.Hover('Docstring not found'));
-            } else {
-                let currentWord: string;
-                currentWord = document.lineAt(position.line).text.slice(wordRange.start.character, wordRange.end.character);
-                const ns = cljParser.getNamespace(document.getText());
+        let wordRange = document.getWordRangeAtPosition(position);
+        if (wordRange === undefined)
+            return Promise.resolve(new vscode.Hover('Docstring not found'));
 
-                nreplClient.info(currentWord, ns, (info) => {
-                    if (info.doc) {
-                        resolve(new vscode.Hover(info.doc));
-                    }
-                    reject();
-                });
+        let currentWord: string;
+        currentWord = document.lineAt(position.line).text.slice(wordRange.start.character, wordRange.end.character);
+        const ns = cljParser.getNamespace(document.getText());
+
+        return nreplClient.info(currentWord, ns).then(info => {
+            if (info.doc) {
+                return Promise.resolve(new vscode.Hover(info.doc));
             }
+            return Promise.reject(undefined);
         });
     }
 

--- a/src/clojureSignature.ts
+++ b/src/clojureSignature.ts
@@ -28,16 +28,14 @@ export class ClojureSignatureProvider implements vscode.SignatureHelpProvider {
             return Promise.reject('No expression found.');
 
         const ns = cljParser.getNamespace(document.getText());
-        return new Promise<vscode.SignatureHelp>((resolve, reject) => {
-            nreplClient.info(exprInfo.functionName, ns, info => {
-                if (!info.name) // sometimes info brings just a list of suggestions (example: .MAX_VALUE)
-                    return reject('No signature info found.');
+        return nreplClient.info(exprInfo.functionName, ns).then(info => {
+            if (!info.name) // sometimes info brings just a list of suggestions (example: .MAX_VALUE)
+                return Promise.reject('No signature info found.');
 
-                if (!!info['special-form'])
-                    return resolve(getSpecialFormSignatureHelp(info, exprInfo.parameterPosition));
+            if (!!info['special-form'])
+                return Promise.resolve(getSpecialFormSignatureHelp(info, exprInfo.parameterPosition));
 
-                return resolve(getFunctionSignatureHelp(info, exprInfo.parameterPosition));
-            });
+            return Promise.resolve(getFunctionSignatureHelp(info, exprInfo.parameterPosition));
         });
     }
 

--- a/src/clojureSuggest.ts
+++ b/src/clojureSuggest.ts
@@ -21,50 +21,40 @@ export class ClojureCompletionItemProvider implements vscode.CompletionItemProvi
         if (!cljConnection.isConnected())
             return Promise.reject('No nREPL connected.');
 
-        return new Promise<vscode.CompletionList>((resolve, reject) => {
-            let document = vscode.window.activeTextEditor.document;
+        // TODO: Use VSCode means for getting a current word
+        let lineText = document.lineAt(position.line).text;
+        let words: string[] = lineText.split(' ');
+        let currentWord = words[words.length - 1].replace(/^[\('\[\{]+|[\)\]\}]+$/g, '');
+        let text = document.getText()
+        let ns = cljParser.getNamespace(text);
 
-            // TODO: Use VSCode means for getting a current word
-            let lineText = document.lineAt(position.line).text;
-            let words: string[] = lineText.split(' ');
-            let currentWord = words[words.length - 1].replace(/^[\('\[\{]+|[\)\]\}]+$/g, '');
-            let text = document.getText()
-            let ns = cljParser.getNamespace(text);
+        let currentWordLength: number = currentWord.length;
 
-            let currentWordLength: number = currentWord.length;
+        let buildInsertText = (suggestion: string) => {
+            return suggestion[0] === '.' ? suggestion.slice(1) : suggestion;
+        }
 
-            let buildInsertText = (suggestion: string) => {
-                return suggestion[0] === '.' ? suggestion.slice(1) : suggestion;
-            }
+        return nreplClient.complete(currentWord, ns).then(completions => {
+            if (!('completions' in completions))
+                return Promise.reject(undefined);
 
-            nreplClient.complete(currentWord, ns, (completions) => {
-                let suggestions = [];
-                if ('completions' in completions) {
-                    completions.completions.forEach(element => {
-                        suggestions.push({
-                            label: element.candidate,
-                            kind: mappings[element.type] || vscode.CompletionItemKind.Text,
-                            insertText: buildInsertText(element.candidate)
-                        })
-                    })
-                } else {
-                    return reject();
-                }
-                let completionList: vscode.CompletionList = new vscode.CompletionList(suggestions, false);
-                resolve(completionList);
-            });
-        })
+            let suggestions = completions.completions.map(element => ({
+                label: element.candidate,
+                kind: mappings[element.type] || vscode.CompletionItemKind.Text,
+                insertText: buildInsertText(element.candidate)
+            }));
+            let completionList: vscode.CompletionList = new vscode.CompletionList(suggestions, false);
+            return Promise.resolve(completionList);
+        });
     }
 
     public resolveCompletionItem(item: vscode.CompletionItem, token: vscode.CancellationToken): Thenable<vscode.CompletionItem> {
-        return new Promise<vscode.CompletionItem>((resolve, reject) => {
-            let document = vscode.window.activeTextEditor.document;
-            let ns = cljParser.getNamespace(document.getText());
-            nreplClient.info(item.label, ns, (info) => {
-                item.documentation = info.doc;
-                resolve(item);
-            });
-        })
+        let document = vscode.window.activeTextEditor.document;
+        let ns = cljParser.getNamespace(document.getText());
+        return nreplClient.info(item.label, ns).then(info => {
+            item.documentation = info.doc;
+            return Promise.resolve(item);
+        });
     }
 
 }

--- a/src/nreplClient.ts
+++ b/src/nreplClient.ts
@@ -42,14 +42,14 @@ interface nREPLCloseMessage {
     op: string;
 }
 
-const complete = (symbol: string, ns: string, callback): void => {
+const complete = (symbol: string, ns: string): Promise<any> => {
     const msg: nREPLCompleteMessage = { op: 'complete', symbol, ns };
-    send(msg).then(respObjs => callback(respObjs[0]));
+    return send(msg).then(respObjs => respObjs[0]);
 };
 
-const info = (symbol: string, ns: string, callback) => {
+const info = (symbol: string, ns: string): Promise<any> => {
     const msg: nREPLInfoMessage = { op: 'info', symbol, ns };
-    send(msg).then(respObjs => callback(respObjs[0]));
+    return send(msg).then(respObjs => respObjs[0]);
 };
 
 const evaluate = (code: string): Promise<any[]> => clone().then((new_session) => {


### PR DESCRIPTION
Convert a few callers who had to wrap the callbacks in Promises to use the .then() Promise-transforming APIs instead.

Removed a duplicate definition of 'document' in clojureSuggest.ts which was flagged as a warning after this refactoring.