### PR TITLE
Ignore nrepl process stderr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "clojure",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/nreplController.ts
+++ b/src/nreplController.ts
@@ -46,13 +46,19 @@ const start = (): Promise<CljConnectionInformation> => {
         });
 
         nreplProcess.stderr.on('data', data => {
+            console.info('nrepl stderr =>', data.toString());
+        });
+
+        nreplProcess.on('exit', (code, signal) => {
+            console.info(`nREPL exit => ${code} / Signal: ${signal}`);
             stop();
-            return reject(`This error happened with our nREPL process: ${data}`);
+            return reject();
         });
 
         nreplProcess.on('close', (code, signal) => {
+            console.info(`nREPL close => ${code} / Signal: ${signal}`);
             stop();
-            return reject(`Our nREPL was closed. Code: ${code} / Signal: ${signal}`);
+            return reject();
         });
     });
 };


### PR DESCRIPTION
nrepl process uses stderr to notify stuff other than error. When it's fired, it doesn't mean that nrepl didn't work.

This closes #47 and closes #48.