### PR TITLE
Add rudimentary tests for cljParser.getNamespace

### DIFF
--- a/test/cljParser.test.ts
+++ b/test/cljParser.test.ts
@@ -1,0 +1,31 @@
+import * as assert from 'assert';
+import {cljParser} from '../src/cljParser';
+
+suite('cljParser', () => {
+    let cases = [
+        ['user', ''],
+        ['foo', '(ns foo)'],
+        ['foo', '\n(ns foo)'],
+        ['foo', '\t(ns foo)'],
+        ['foo', '\t(ns\tfoo)'],
+        ['foo-bar', '(ns foo-bar)'],
+        ['bar', '(ns bar)'],
+        ['baz', '(ns baz "docstring")'],
+        ['qux', `(ns qux
+                    "docstring")`],
+        ['foo.bar', '(ns foo.bar)'],
+        ['foo.bar-baz', '(ns foo.bar-baz)'],
+        ['foo.bar', `(ns foo.bar
+                        (:refer-clojure :exclude [ancestors printf])
+                        (:require (clojure.contrib sql combinatorics))
+                        (:use (my.lib this that))
+                        (:import (java.util Date Timer Random)
+                            (java.sql Connection Statement)))`],
+        ['bar', '(in-ns \'bar)'],
+    ];
+    for (let [want, input] of cases) {
+        test(`getNamespace("${input}") should be "${want}"`, () => {
+            assert.equal(cljParser.getNamespace(input), want);
+        });
+    }
+});


### PR DESCRIPTION
These are fairly minimal, just testing one function in a table-driven style, but hopefully they can give us some confidence next time we update the parsing regex.

I've tried to test tabs, newlines, spaces, and a few optional parameters to 'ns', making sure that we're robust to all of these.

Also added one test that checks we work with the 'in-ns' form.

You can run these tests from VS Code's debug tag using the 'Launch Tests' task. Later on, we could work at getting these tests to run without spinning up an entire VS Code instance (they're unit tests, they shouldn't need a VS Code UI to run).