### PR TITLE
Added automatic nREPL startup for Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "clojure",
-    "version": "0.7.4",
+    "version": "0.7.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -298,6 +298,27 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "cross-spawn": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+            "requires": {
+                "lru-cache": "4.1.1",
+                "shebang-command": "1.2.0",
+                "which": "1.2.14"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+                    "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+                    "requires": {
+                        "pseudomap": "1.0.2",
+                        "yallist": "2.1.2"
+                    }
+                }
+            }
         },
         "cryptiles": {
             "version": "2.0.5",
@@ -1327,6 +1348,11 @@
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+        },
         "isobject": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
@@ -1929,6 +1955,11 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+        },
         "punycode": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -2158,6 +2189,19 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
             "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
             "dev": true
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "requires": {
+                "shebang-regex": "1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "sigmund": {
             "version": "1.0.1",
@@ -2705,6 +2749,14 @@
                 }
             }
         },
+        "which": {
+            "version": "1.2.14",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+            "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+            "requires": {
+                "isexe": "2.0.0"
+            }
+        },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -2716,6 +2768,11 @@
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
             "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
             "dev": true
+        },
+        "yallist": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         },
         "yauzl": {
             "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     },
     "dependencies": {
         "bencoder": "^0.0.5",
+        "cross-spawn": "^5.1.0",
         "jszip": "^3.1.1"
     },
     "repository": {

--- a/src/nreplController.ts
+++ b/src/nreplController.ts
@@ -1,6 +1,7 @@
 import 'process';
 import * as vscode from 'vscode';
-import { spawn, ChildProcess } from 'child_process';
+import { spawn } from 'cross-spawn';
+import { ChildProcess } from 'child_process';
 
 import { CljConnectionInformation } from './cljConnection';
 

--- a/src/nreplController.ts
+++ b/src/nreplController.ts
@@ -1,6 +1,7 @@
 import 'process';
 import * as vscode from 'vscode';
-import { spawn, ChildProcess } from 'child_process';
+import { spawn } from 'cross-spawn';
+import { ChildProcess } from 'child_process';
 
 import { CljConnectionInformation } from './cljConnection';
 
@@ -33,7 +34,7 @@ const start = (): Promise<CljConnectionInformation> => {
     if (isStarted())
         return Promise.reject({ nreplError: 'nREPL already started.' });
 
-    nreplProcess = spawn('lein', LEIN_ARGS, { cwd: vscode.workspace.rootPath, detached: true });
+    nreplProcess = spawn('lein', LEIN_ARGS, { cwd: vscode.workspace.rootPath });
 
     return new Promise((resolve, reject) => {
         nreplProcess.stdout.addListener('data', data => {


### PR DESCRIPTION
Previously, when opening a .clj file on Windows the nREPL server would not be started automatically because it would throw an error when spawning the lein process.

Apparently spawn behaves a bit differently on Windows. Using the cross-spawn modules gets rid of some of the problems.

However, I also had to remove the detached option for the spawn to work on Windows. Is there a particular reason for having it set to true at all? I tested it on a Fedora-VM and it seemed to work fine without detached being set to true.