### PR TITLE
Add configuration option to disable automatic `lein repl` on VS Code start

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,18 @@
                 "command": "clojureVSCode.formatFile",
                 "title": "Clojure: Format file or selection"
             }
-        ]
+        ],
+        "configuration": {
+            "type": "object",
+            "title": "Clojure extension configuration",
+            "properties": {
+                "clojureVSCode.autoStartNRepl": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Automatically run `lein repl` and connect to it when VS Code loads"
+                }
+            }
+        }
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",

--- a/src/clojureMain.ts
+++ b/src/clojureMain.ts
@@ -16,8 +16,10 @@ export function activate(context: vscode.ExtensionContext) {
     cljConnection.setCljContext(context);
     context.subscriptions.push(nreplController);
     cljConnection.disconnect(false);
-
-    cljConnection.startNRepl();
+    var config = vscode.workspace.getConfiguration('clojureVSCode');
+    if (config.autoStartNRepl) {
+        cljConnection.startNRepl();
+    }
 
     vscode.commands.registerCommand('clojureVSCode.manuallyConnectToNRepl', cljConnection.manuallyConnect);
     vscode.commands.registerCommand('clojureVSCode.stopDisconnectNRepl', cljConnection.disconnect);


### PR DESCRIPTION
There’re plenty of options to start NRepl and everybody’s setup is different. Let’s give people a choice to start their project the way they prefer to and connect manually, at least as an option