### PR TITLE
format: fix linebreak issues

### DIFF
--- a/src/clojureFormat.ts
+++ b/src/clojureFormat.ts
@@ -32,7 +32,7 @@ export const formatFile = (textEditor: vscode.TextEditor, edit: vscode.TextEdito
             };
             if (('value' in value[1]) && (value[1].value != 'nil')) {
                 const new_content: string = value[1].value.slice(1, -1)
-                    .replace(/\\n/g, '\n')
+                    .replace(/(?!\B"[^"]*)\\n(?![^"]*"\B)/g, '\n')
                     .replace(/\\"/g, '"')
                     .replace(/\\\\/g, '\\') // remove quotes, backslashes, and unescape
                 let selection = textEditor.selection;


### PR DESCRIPTION
when unescaping the content returned from cljfmt, do not unescape newlines
that are part of strings - fixes #64