### PR TITLE
Add a channel for nREPL output to the Output Window

### DIFF
--- a/src/cljConnection.ts
+++ b/src/cljConnection.ts
@@ -136,12 +136,10 @@ const startNRepl = (): void => {
         .then(connectionInfo => nreplConnection = connectionInfo)
         .then(() => nreplClient.test(nreplConnection))
         .then(stopLoadingAnimation)
-        .then(() => saveConnection(nreplConnection))
-        .catch(({ nreplError }) => {
+        .then(() => saveConnection(nreplConnection), ({ nreplError }) => {
             stopLoadingAnimation();
             if (!nreplError)
                 nreplError = "Can't start nREPL.";
-
             disconnect(false);
             vscode.window.showErrorMessage(nreplError);
         });


### PR DESCRIPTION
Add a channel to show nREPL output to the user. This channel will be
used for the following:

stdout:

Any stdout messages are sent to the channel.

stderr:

Any stderr messages are sent to the channel, and the channel is brought
to the front to make the user aware.

exit:

If the nREPL closes before be we can load the port, then the exit code
is printed to the nREPL output channel, and the channel is brough to the
front.

Fixes #52
Fixed #69

Also fixes a bug where the 'Starting nREPL' status message would never
clear if the repl failed to start.
<img width="1289" alt="screen shot 2018-02-06 at 15 39 09" src="https://user-images.githubusercontent.com/448001/35868266-ea2bce96-0b53-11e8-965b-364017852ca2.png">

