### PR TITLE
Disconnect if connection refused

### DIFF
--- a/src/nreplClient.ts
+++ b/src/nreplClient.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import * as net from 'net';
 import { Buffer } from 'buffer';
 
@@ -105,6 +106,10 @@ const send = (msg: nREPLCompleteMessage | nREPLInfoMessage | nREPLEvalMessage | 
         client.on('error', error => {
             client.end();
             client.removeAllListeners();
+            if (error['code'] == 'ECONNREFUSED') {
+                vscode.window.showErrorMessage('Connection refused.');
+                cljConnection.disconnect();
+            }
             reject(error);
         });
 


### PR DESCRIPTION
If remote REPL is closed and we try to eval some form or format the file we will not see the result nor error message. So I suggest to disconnect the client in this case and show the error of course.

Not sure it's the best place for such a code, but i didn't find better one.