### PR TITLE
Don't focus output window on eval

### DIFF
--- a/src/clojureEval.ts
+++ b/src/clojureEval.ts
@@ -195,7 +195,7 @@ function handleError(outputChannel: vscode.OutputChannel, selection: vscode.Sele
                     outputChannel.appendLine(`    ${trace.class}.${trace.method} (${trace.file}:${trace.line})`);
             });
 
-            outputChannel.show();
+            outputChannel.show(true);
             nreplClient.close(session);
         });
 }
@@ -211,7 +211,7 @@ function handleSuccess(outputChannel: vscode.OutputChannel, showResults: boolean
                 outputChannel.append(respObj.err);
             if (respObj.value)
                 outputChannel.appendLine(`=> ${respObj.value}`);
-            outputChannel.show();
+            outputChannel.show(true);
         });
     }
     nreplClient.close(respObjs[0].session);


### PR DESCRIPTION
Most of the time I don't interact with the output window after evaluating code.
Suggested change keeps focus on the editor window after evaluation.