### PR TITLE
Add ability to evaluate current and outer block

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outDir": "${workspaceRoot}/out/src",
+            "outFiles": ["${workspaceRoot}/out/src/**/*.js"],
             "preLaunchTask": "npm"
         },
         {
@@ -18,10 +18,14 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
+            "args": [
+                "--disable-extensions",
+                "--extensionDevelopmentPath=${workspaceRoot}",
+                "--extensionTestsPath=${workspaceRoot}/out/test"
+            ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outDir": "${workspaceRoot}/out/test",
+            "outFiles": ["${workspaceRoot}/out/test/**/*.js"],
             "preLaunchTask": "npm"
         }
     ]

--- a/src/cljParser.ts
+++ b/src/cljParser.ts
@@ -1,3 +1,5 @@
+import * as vscode from 'vscode';
+
 interface ExpressionInfo {
     functionName: string;
     parameterPosition: number;
@@ -13,16 +15,18 @@ const CLJ_TEXT_ESCAPE = `\\`;
 const CLJ_COMMENT_DELIMITER = `;`;
 const R_CLJ_WHITE_SPACE = /\s|,/;
 const R_CLJ_OPERATOR_DELIMITERS = /\s|,|\(|{|\[/;
+const OPEN_CLJ_BLOCK_BRACKET = `(`;
+const CLOSE_CLJ_BLOCK_BRACKET = `)`;
 
 /** { close_char open_char } */
 const CLJ_EXPRESSION_DELIMITERS: Map<string, string> = new Map<string, string>([
     [`}`, `{`],
-    [`)`, `(`],
+    [CLOSE_CLJ_BLOCK_BRACKET, OPEN_CLJ_BLOCK_BRACKET],
     [`]`, `[`],
     [CLJ_TEXT_DELIMITER, CLJ_TEXT_DELIMITER],
 ]);
 
-const getExpressionInfo = (text: string): ExpressionInfo | undefined  => {
+const getExpressionInfo = (text: string): ExpressionInfo | undefined => {
     text = removeCljComments(text);
     const relativeExpressionInfo = getRelativeExpressionInfo(text);
     if (!relativeExpressionInfo)
@@ -135,8 +139,121 @@ const getNamespace = (text: string): string => {
     return m ? m[1] : 'user';
 };
 
+// end index is not included
+const range = (start: number, end: number): Array<number> => {
+    if (start < end) {
+        const length = end - start;
+        return Array.from(Array(length), (_, i) => start + i);
+    } else {
+        const length = start - end;
+        return Array.from(Array(length), (_, i) => start - i);
+    }
+}
+
+const findNearestBracket = (
+    editor: vscode.TextEditor,
+    current: vscode.Position,
+    bracket: string): vscode.Position | undefined => {
+
+    const isBackward = bracket == OPEN_CLJ_BLOCK_BRACKET;
+    // "open" and "close" brackets as keys related to search direction
+    let openBracket = OPEN_CLJ_BLOCK_BRACKET,
+        closeBracket = CLOSE_CLJ_BLOCK_BRACKET;
+    if (isBackward) {
+        [closeBracket, openBracket] = [openBracket, closeBracket]
+    };
+
+    let bracketStack: string[] = [],
+        // get begin of text if we are searching `(` and end of text otherwise
+        lastLine = isBackward ? -1 : editor.document.lineCount,
+        lineRange = range(current.line, lastLine);
+
+    for (var line of lineRange) {
+        const textLine = editor.document.lineAt(line);
+        if (textLine.isEmptyOrWhitespace) continue;
+
+        // get line and strip clj comments
+        const firstChar = textLine.firstNonWhitespaceCharacterIndex,
+            strippedLine = removeCljComments(textLine.text);
+        let startColumn = firstChar,
+            endColumn = strippedLine.length;
+        if (isBackward) {
+            // dec both as `range` doesn't include an end edge
+            [startColumn, endColumn] = [endColumn - 1, startColumn - 1];
+        }
+
+        // get current current char index if it is first iteration of loop
+        if (current.line == line) {
+            let currentColumn = current.character;
+            // set current position as start
+            if (isBackward) {
+                if (currentColumn <= endColumn) continue;
+                startColumn = currentColumn;
+                if ([openBracket, closeBracket].indexOf(strippedLine[startColumn]) > -1) {
+                    startColumn--;
+                };
+            } else if (currentColumn <= endColumn) {
+                startColumn = currentColumn;
+            }
+        }
+
+        // search nearest bracket
+        for (var column of range(startColumn, endColumn)) {
+            const char = strippedLine[column];
+            if (!bracketStack.length && char == bracket) {
+                // inc column if `char` is a `)` to get correct selection
+                if (!isBackward) column++;
+                return new vscode.Position(line, column);
+            } else if (char == openBracket) {
+                bracketStack.push(char);
+                // check if inner block is closing
+            } else if (char == closeBracket && bracketStack.length > 0) {
+                bracketStack.pop();
+            };
+        };
+    }
+};
+
+
+const getCurrentBlock = (
+    editor: vscode.TextEditor,
+    left?: vscode.Position,
+    right?: vscode.Position): vscode.Selection | undefined => {
+
+    if (!left || !right) {
+        left = right = editor.selection.active;
+    };
+    const prevBracket = findNearestBracket(editor, left, OPEN_CLJ_BLOCK_BRACKET);
+    if (!prevBracket) return;
+
+    const nextBracket = findNearestBracket(editor, right, CLOSE_CLJ_BLOCK_BRACKET);
+    if (nextBracket) {
+        return new vscode.Selection(prevBracket, nextBracket);
+    }
+};
+
+const getOuterBlock = (
+    editor: vscode.TextEditor,
+    left?: vscode.Position,
+    right?: vscode.Position): vscode.Selection | undefined => {
+
+    if (!left || !right) {
+        left = right = editor.selection.active;
+    };
+
+    const nextBlock = getCurrentBlock(editor, left, right);
+
+    if (nextBlock) {
+        return getOuterBlock(editor, nextBlock.anchor, nextBlock.active);
+    } else if (right != left) {
+        return new vscode.Selection(left, right);
+    };
+}
+
 export const cljParser = {
     R_CLJ_WHITE_SPACE,
     getExpressionInfo,
     getNamespace,
+    getCurrentBlock,
+    getOuterBlock,
 };

--- a/src/cljParser.ts
+++ b/src/cljParser.ts
@@ -139,7 +139,11 @@ const getNamespace = (text: string): string => {
     return m ? m[1] : 'user';
 };
 
-// end index is not included
+/** A range of numbers between `start` and `end`.
+
+ * The `end` index is not included and `end` could be before `start`.
+ * Whereas default `vscode.Range` requires that `start` should be
+ * before or equal than `end`. */
 const range = (start: number, end: number): Array<number> => {
     if (start < end) {
         const length = end - start;
@@ -199,7 +203,7 @@ const findNearestBracket = (
                 // forward direction
                 startColumn = currentColumn;
                 if (strippedLine[startColumn - 1] == CLOSE_CLJ_BLOCK_BRACKET) {
-                    startColumn--;
+                    return new vscode.Position(line, startColumn);
                 } else if (strippedLine[startColumn] == OPEN_CLJ_BLOCK_BRACKET) {
                     startColumn++;
                 };

--- a/src/clojureEval.ts
+++ b/src/clojureEval.ts
@@ -7,8 +7,7 @@ import { TestListener } from './testRunner';
 
 const HIGHLIGHTING_TIMEOUT = 350;
 const BLOCK_DECORATION_TYPE = vscode.window.createTextEditorDecorationType({
-    backgroundColor: { id: 'editor.findMatchHighlightBackground' },
-    borderRadius: '2px',
+    backgroundColor: { id: 'editor.findMatchHighlightBackground' }
 });
 
 export function clojureEval(outputChannel: vscode.OutputChannel): void {

--- a/test/cljParser.test.ts
+++ b/test/cljParser.test.ts
@@ -1,7 +1,11 @@
 import * as assert from 'assert';
-import {cljParser} from '../src/cljParser';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { cljParser } from '../src/cljParser';
 
-suite('cljParser', () => {
+const testFolderLocation = '/../../test/documents/';
+
+suite('cljParser.getNamespace', () => {
     let cases = [
         ['user', ''],
         ['foo', '(ns foo)'],
@@ -29,3 +33,83 @@ suite('cljParser', () => {
         });
     }
 });
+
+suite('cljParser.getCurrentBlock', () => {
+    // title, line, character, expected
+    let cases: [string, number, number, string | undefined][] = [
+        ['Position on the same line', 16, 9, '(prn "test")'],
+        ['Position in the middle of multiline block', 22, 6,
+            '(->> numbers\n' +
+            '      (map inc)\n' +
+            '      (prn))'],
+        ['Ignore inline clj comments', 19, 16,
+            '(let [numbers [1 2 3]\n' +
+            '        VAL (atom {:some "DATA"})]\n' +
+            '  ; missing left bracket prn "hided text") in comment\n' +
+            '    (prn [@VAL])\n' +
+            '    (->> numbers\n' +
+            '      (map inc)\n' +
+            '      (prn)))'],
+        ['Comment form will be evaluated', 27, 14, '(prn "COMMENT")'],
+        ['Eval only inside bracket from right side', 23, 11,
+            '(->> numbers\n' +
+            '      (map inc)\n' +
+            '      (prn))'],
+        ['Eval only inside bracket from left side', 28, 5,
+            '((comp #(str % "!") name) :test)'],
+        ['Eval only round bracket block', 20, 12, '(prn [@VAL])'],
+        ['Eval when only inside of the block', 23, 14, undefined],
+        ['Begin of file', 0, 0, undefined],
+        ['End of file', 37, 0, undefined],
+    ];
+    testBlockSelection('Eval current block', cljParser.getCurrentBlock, 'evalBlock.clj', cases);
+});
+
+suite('cljParser.getOuterBlock', () => {
+    // title, line, character, expected
+    let cases: [string, number, number, string | undefined][] = [
+        ['Get outermost block of function definition', 11, 20,
+            '(defn new-system-dev\n' +
+            '  []\n' +
+            '  (let [_ 1]\n' +
+            '    (new-system (config))))'],
+        ['Outer block not found', 23, 14, undefined],
+        ['Begin of file', 0, 0, undefined],
+        ['End of file', 37, 0, undefined],
+    ];
+    testBlockSelection('Eval outer block', cljParser.getOuterBlock, 'evalBlock.clj', cases);
+});
+
+function testBlockSelection(
+    title: string,
+    getBlockFn: CallableFunction,
+    fileName: string,
+    cases: [string, number, number, string | undefined][]) {
+
+    test(title, async () => {
+        const editor = await getEditor(fileName);
+
+        for (let [title, line, character, expected] of cases) {
+            const currentPosition = new vscode.Position(line, character);
+            editor.selection = new vscode.Selection(currentPosition, currentPosition);
+            let blockSelection = getBlockFn(editor);
+            blockSelection = blockSelection ? editor.document.getText(blockSelection) : blockSelection;
+            assert.equal(blockSelection, expected, title)
+        };
+        vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+    });
+};
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+};
+
+async function getEditor(fileName: string): Promise<vscode.TextEditor> {
+    const uri = vscode.Uri.file(path.join(__dirname + testFolderLocation + fileName)),
+        document = await vscode.workspace.openTextDocument(uri),
+        editor = await vscode.window.showTextDocument(document);
+    await sleep(500);
+    return editor;
+};

--- a/test/cljParser.test.ts
+++ b/test/cljParser.test.ts
@@ -38,7 +38,7 @@ suite('cljParser.getCurrentBlock', () => {
     // title, line, character, expected
     let cases: [string, number, number, string | undefined][] = [
         ['Position on the same line', 16, 9, '(prn "test")'],
-        ['Position in the middle of multiline block', 22, 6,
+        ['Position at the middle of multiline block', 22, 5,
             '(->> numbers\n' +
             '      (map inc)\n' +
             '      (prn))'],
@@ -51,16 +51,18 @@ suite('cljParser.getCurrentBlock', () => {
             '      (map inc)\n' +
             '      (prn)))'],
         ['Comment form will be evaluated', 27, 14, '(prn "COMMENT")'],
-        ['Eval only inside bracket from right side', 23, 11,
-            '(->> numbers\n' +
-            '      (map inc)\n' +
-            '      (prn))'],
-        ['Eval only inside bracket from left side', 28, 5,
-            '((comp #(str % "!") name) :test)'],
+        ['Eval only outside bracket from right side', 23, 11, '(prn)'],
+        ['Eval only outside bracket from left side', 28, 5,
+            '(comp #(str % "!") name)'],
         ['Eval only round bracket block', 20, 12, '(prn [@VAL])'],
-        ['Eval when only inside of the block', 23, 14, undefined],
-        ['Begin of file', 0, 0, undefined],
-        ['End of file', 37, 0, undefined],
+        ['Eval when only inside of the block', 24, 0, undefined],
+        ['Begin of file', 0, 0,
+            '(ns user\n' +
+            '    (:require [clojure.tools.namespace.repl :refer [set-refresh-dirs]]\n' +
+            '              [reloaded.repl :refer [system stop go reset]]\n' +
+            '              [myproject.config :refer [config]]\n' +
+            '              [myproject.core :refer [new-system]]))'],
+        ['End of file', 37, 0, undefined]
     ];
     testBlockSelection('Eval current block', cljParser.getCurrentBlock, 'evalBlock.clj', cases);
 });
@@ -73,8 +75,23 @@ suite('cljParser.getOuterBlock', () => {
             '  []\n' +
             '  (let [_ 1]\n' +
             '    (new-system (config))))'],
-        ['Outer block not found', 23, 14, undefined],
-        ['Begin of file', 0, 0, undefined],
+        ['Outer block from outside left bracket', 8, 0,
+            '(defn new-system-dev\n' +
+            '  []\n' +
+            '  (let [_ 1]\n' +
+            '    (new-system (config))))'],
+        ['Outer block from outside right bracket', 28, 38,
+            '(comment\n' +
+            '  (do\n' +
+            '    #_(prn "COMMENT")\n' +
+            '    ((comp #(str % "!") name) :test)))'],
+        ['Outer block not found', 24, 0, undefined],
+        ['Begin of file', 0, 0,
+            '(ns user\n' +
+            '    (:require [clojure.tools.namespace.repl :refer [set-refresh-dirs]]\n' +
+            '              [reloaded.repl :refer [system stop go reset]]\n' +
+            '              [myproject.config :refer [config]]\n' +
+            '              [myproject.core :refer [new-system]]))'],
         ['End of file', 37, 0, undefined],
     ];
     testBlockSelection('Eval outer block', cljParser.getOuterBlock, 'evalBlock.clj', cases);

--- a/test/cljParser.test.ts
+++ b/test/cljParser.test.ts
@@ -99,7 +99,7 @@ suite('cljParser.getOuterBlock', () => {
 
 function testBlockSelection(
     title: string,
-    getBlockFn: CallableFunction,
+    getBlockFn: (editor: vscode.TextEditor) => vscode.Selection | undefined,
     fileName: string,
     cases: [string, number, number, string | undefined][]) {
 
@@ -109,9 +109,9 @@ function testBlockSelection(
         for (let [title, line, character, expected] of cases) {
             const currentPosition = new vscode.Position(line, character);
             editor.selection = new vscode.Selection(currentPosition, currentPosition);
-            let blockSelection = getBlockFn(editor);
-            blockSelection = blockSelection ? editor.document.getText(blockSelection) : blockSelection;
-            assert.equal(blockSelection, expected, title)
+            const blockSelection = getBlockFn(editor),
+                  text = blockSelection ? editor.document.getText(blockSelection) : blockSelection;
+            assert.equal(text, expected, title)
         };
         vscode.commands.executeCommand('workbench.action.closeActiveEditor');
     });
@@ -127,6 +127,6 @@ async function getEditor(fileName: string): Promise<vscode.TextEditor> {
     const uri = vscode.Uri.file(path.join(__dirname + testFolderLocation + fileName)),
         document = await vscode.workspace.openTextDocument(uri),
         editor = await vscode.window.showTextDocument(document);
-    await sleep(500);
+    await sleep(600);
     return editor;
 };

--- a/test/documents/evalBlock.clj
+++ b/test/documents/evalBlock.clj
@@ -1,0 +1,37 @@
+(ns user
+    (:require [clojure.tools.namespace.repl :refer [set-refresh-dirs]]
+              [reloaded.repl :refer [system stop go reset]]
+              [myproject.config :refer [config]]
+              [myproject.core :refer [new-system]]))
+
+(set-refresh-dirs "dev" "src" "test")
+
+(defn new-system-dev
+  []
+  (let [_ 1]
+    (new-system (config))))
+
+(reloaded.repl/set-init! #(new-system-dev))
+
+(comment
+  (prn "test")  ; block in comment (prn "comment") some extra text;
+  (let [numbers [1 2 3]
+        VAL (atom {:some "DATA"})]
+  ; missing left bracket prn "hided text") in comment
+    (prn [@VAL])
+    (->> numbers
+      (map inc)
+      (prn))))
+
+(comment
+  (do
+    #_(prn "COMMENT")
+    ((comp #(str % "!") name) :test)))
+
+(comment
+  (go)
+  (reset)
+  (stop)
+  (keys system))
+
+(prn "THE WHOLE FILE HAS BEEN EVALUATED")


### PR DESCRIPTION
The main feature that was added in this PR  is:
- if the selection is empty try to find a nearest current block and evaluate it;
- evaluate selection if it exists;
- otherwise, if the current block couldn't be found eval whole file.

The same for an outer block.

Here _block_ means everything between round brackets `(...)`. It is slightly different than Atom's Proto Repl implementation which offers evaluation of vectors `[...]`.

Caveats:
- doesn't handle any string literals, so unmatched round brackets inside string could brake block evaluation.

Resolves #61 

A short demonstration:
_(keybindnigs used for recording: `ctrl+n`: "Eval and show the result", `ctrl+alt+e`: "Eval")_
![eval-block](https://user-images.githubusercontent.com/1375411/68340984-874bc280-00f8-11ea-9eea-34c7160b8c05.gif)