### PR TITLE
Add optional ability to show evaluation result inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ option in your VSCode settings globally or per-project and connect manually to w
 
 ```clojure
 {:user {:plugins  [[cider/cider-nrepl "0.22.1"]]
-       :dependencies [[cljfmt "0.5.7"]]}}
+        :dependencies [[cljfmt "0.5.7"]]}}
 ```
 
 Alternatively, you can put the code above to your project `project.clj` file.
@@ -75,6 +75,7 @@ The extension contributes the configuration parameters listed in the table below
 |`clojureVSCode.autoStartNRepl`  | Whether to start an nREPL when opening a file or project. |
 |`clojureVSCode.formatOnSave`    | Format files with [cljfmt](https://github.com/weavejester/cljfmt) on save. |
 |`clojureVSCode.cljfmtParameters`| Formatting parameters passed to `cljfmt` each time it runs, e.g. `:indentation? true :remove-surrounding-whitespace? false` |
+|`clojureVSCode.showResultInline`    | Show evaluation result inline. |
 
 ## ClojureScript Project Setup
 

--- a/package.json
+++ b/package.json
@@ -121,11 +121,36 @@
                 },
                 "clojureVSCode.cljfmtParameters": {
                     "type": "string",
-                    "description": "Parameters which will be passed to cljfmt",
+                    "description": "Parameters which will be passed to cljfmt.",
                     "default": ""
+                },
+                "clojureVSCode.showResultInline": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Show evaluation result inline."
                 }
             }
-        }
+        },
+        "colors": [
+			{
+				"id": "clojureVSCode.inlineResultBackground",
+				"description": "Background color of the inline result.",
+				"defaults": {
+					"dark": "#00000000",
+					"light": "#00000000",
+					"highContrast": "#00000000"
+				}
+			},
+			{
+				"id": "clojureVSCode.inlineResultForeground",
+				"description": "Foreground color of the inline result.",
+				"defaults": {
+					"dark": "#99999999",
+					"light": "#99999999",
+					"highContrast": "#99999999"
+				}
+			}
+        ]
     },
     "scripts": {
         "vscode:prepublish": "webpack --mode production",

--- a/src/clojureMain.ts
+++ b/src/clojureMain.ts
@@ -2,7 +2,10 @@ import * as vscode from 'vscode';
 
 import { CLOJURE_MODE, LANGUAGE } from './clojureMode';
 import { ClojureCompletionItemProvider } from './clojureSuggest';
-import { clojureEval, clojureEvalAndShowResult, testNamespace, runAllTests } from './clojureEval';
+import {
+    clojureEval, clojureEvalAndShowResult, testNamespace, runAllTests,
+    clearInlineResultDecorationOnMove
+} from './clojureEval';
 import { ClojureDefinitionProvider } from './clojureDefinition';
 import { ClojureLanguageConfiguration } from './clojureConfiguration';
 import { ClojureHoverProvider } from './clojureHover';
@@ -48,6 +51,11 @@ export function activate(context: vscode.ExtensionContext) {
 
     vscode.workspace.registerTextDocumentContentProvider('jar', new JarContentProvider());
     vscode.languages.setLanguageConfiguration(LANGUAGE, ClojureLanguageConfiguration);
+
+    // events
+    vscode.window.onDidChangeTextEditorSelection(event => {
+        clearInlineResultDecorationOnMove(event);
+    }, null, context.subscriptions);
 }
 
 export function deactivate() { }


### PR DESCRIPTION
Result is shown inline next to evaluated expression and truncated by 150 symbols by default:

![inline_result](https://user-images.githubusercontent.com/1375411/74069697-13c79300-4a10-11ea-9faf-3c2e09c55675.gif)

Resolve #148 